### PR TITLE
feat: add basic theming and theme toggle

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,8 @@
+# Testing
+
+- `pnpm dev` to run the app locally.
+- Use the 🌙/☀️ button in the header to toggle dark and light themes; preference persists.
+- Use the "Skip to content" link (Tab at page load) to jump to the main area.
+- Tab through header controls to ensure focus rings appear.
+- Interact with a post's actions and toggle save state.
+- Resize the browser to mobile widths to verify responsive layout.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,8 +2,49 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-	@apply bg-gray-50 text-gray-900;
+:root {
+  --mwv-background: #f8fafc;
+  --mwv-foreground: #0f172a;
+  --mwv-card: #ffffff;
+  --mwv-muted: #f1f5f9;
+  --mwv-border: #e2e8f0;
+  --mwv-ring: #3b82f6;
 }
 
+.dark {
+  --mwv-background: #0f172a;
+  --mwv-foreground: #f8fafc;
+  --mwv-card: #1e293b;
+  --mwv-muted: #334155;
+  --mwv-border: #475569;
+  --mwv-ring: #3b82f6;
+}
+
+body {
+  @apply bg-mwv-background text-mwv-foreground;
+}
+
+.skip-link {
+  @apply sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-mwv-primary focus:text-mwv-primary-foreground focus:px-3 focus:py-2;
+}
+
+.card {
+  @apply rounded-2xl border border-mwv-border bg-mwv-card shadow-card transition-all duration-150;
+}
+
+.card-hover:hover {
+  @apply shadow-card-hover ring-1 ring-mwv-ring ring-opacity-20 translate-y-[1px];
+}
+
+.pill {
+  @apply rounded-full border border-mwv-border bg-mwv-muted px-2.5 py-1 text-xs;
+}
+
+.skeleton {
+  @apply animate-pulse rounded bg-slate-200/70 dark:bg-slate-700/50;
+}
+
+*:focus-visible {
+  @apply outline-none ring-2 ring-mwv-ring ring-opacity-60 ring-offset-2;
+}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,10 @@ import React from 'react';
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <a href="#main-content" className="skip-link">Skip to content</a>
+        <div id="main-content">{children}</div>
+      </body>
     </html>
   );
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -15,7 +15,7 @@ export default function PostCard({ post }: { post: Post }) {
   const [saved, setSaved] = useState(false);
 
   return (
-    <article className="rounded-lg border bg-white p-4">
+    <article className="card card-hover p-4">
       <header className="mb-2 flex items-start gap-3">
         <Image
           src={post.author.avatarUrl || "/avatar-placeholder.svg"}
@@ -37,21 +37,22 @@ export default function PostCard({ post }: { post: Post }) {
 
       <footer className="mt-3 flex flex-wrap items-center gap-3 text-sm text-gray-600">
         <button
-          className="rounded px-2 py-1 hover:bg-gray-50"
+          className="flex items-center gap-1 rounded px-2 py-1 hover:bg-mwv-muted transition-all duration-150"
           title="Draft a motion from this post"
         >
-          Promote to Motion
+          <span aria-hidden>🚀</span>
+          Promote
         </button>
-        <button className="rounded px-2 py-1 hover:bg-gray-50">Comment</button>
-        <button className="rounded px-2 py-1 hover:bg-gray-50">Share</button>
+        <button className="rounded px-2 py-1 hover:bg-mwv-muted transition-all duration-150">Comment</button>
+        <button className="rounded px-2 py-1 hover:bg-mwv-muted transition-all duration-150">Share</button>
         <button
-          className={`rounded px-2 py-1 hover:bg-gray-50 ${saved ? 'text-blue-600' : ''}`}
+          className={`rounded px-2 py-1 hover:bg-mwv-muted transition-all duration-150 ${saved ? 'text-mwv-primary' : ''}`}
           onClick={() => setSaved((s) => !s)}
         >
           {saved ? 'Saved' : 'Save'}
         </button>
         {typeof post.evidenceCount === 'number' && (
-          <span className="ml-auto text-xs text-gray-500">{post.evidenceCount} evidence links</span>
+          <span className="ml-auto pill">{post.evidenceCount} evidence</span>
         )}
       </footer>
     </article>

--- a/src/components/StanceBar.tsx
+++ b/src/components/StanceBar.tsx
@@ -1,7 +1,16 @@
 export type StanceCounts = { for?: number; against?: number; abstain?: number };
-export type StanceBarProps = { forPct?: number; againstPct?: number; abstainPct?: number; counts?: StanceCounts };
+export type StanceBarProps = {
+  forPct?: number;
+  againstPct?: number;
+  abstainPct?: number;
+  counts?: StanceCounts;
+  size?: 'sm' | 'md' | 'lg';
+  labels?: boolean;
+};
 
-export default function StanceBar({ forPct, againstPct, abstainPct, counts }: StanceBarProps) {
+export default function StanceBar({ forPct, againstPct, abstainPct, counts, size = 'md', labels }: StanceBarProps) {
+  const height = { sm: 'h-2', md: 'h-3', lg: 'h-4' }[size];
+  const barClass = `flex ${height} w-full overflow-hidden rounded bg-mwv-muted`;
   if (counts) {
     const forCount = counts.for || 0;
     const againstCount = counts.against || 0;
@@ -10,23 +19,25 @@ export default function StanceBar({ forPct, againstPct, abstainPct, counts }: St
     const _pct = (n: number) => Math.round((n / total) * 100);
     return (
       <div className="w-full">
-        <div className="flex h-3 w-full overflow-hidden rounded bg-gray-100">
+        <div className={barClass}>
           <div style={{ width: `${_pct(forCount)}%` }} className="bg-emerald-500" />
           <div style={{ width: `${_pct(againstCount)}%` }} className="bg-rose-500" />
           <div style={{ width: `${_pct(abstainCount)}%` }} className="bg-yellow-400" />
         </div>
-        <div className="mt-2 flex items-center justify-between text-xs text-gray-600">
-          <div>For: {forCount}</div>
-          <div>Against: {againstCount}</div>
-          <div>Abstain: {abstainCount}</div>
-        </div>
+        {labels !== false && (
+          <div className="mt-2 flex items-center justify-between text-xs text-gray-600">
+            <div>For: {forCount}</div>
+            <div>Against: {againstCount}</div>
+            <div>Abstain: {abstainCount}</div>
+          </div>
+        )}
       </div>
     );
   }
   // Percentage mode
 
   return (
-    <div className="h-2.5 w-full overflow-hidden rounded bg-gray-200 flex" role="img" aria-label="Stance distribution">
+    <div className={barClass} role="img" aria-label="Stance distribution">
       <div className="h-full bg-emerald-500" style={{ width: `${forPct || 0}%` }} aria-label={`For ${forPct || 0}%`} />
       <div className="h-full bg-rose-500" style={{ width: `${againstPct || 0}%` }} aria-label={`Against ${againstPct || 0}%`} />
       <div className="h-full bg-gray-500" style={{ width: `${abstainPct || 0}%` }} aria-label={`Abstain ${abstainPct || 0}%`} />

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDark = stored ? stored === 'dark' : prefersDark;
+    if (isDark) {
+      document.documentElement.classList.add('dark');
+      setDark(true);
+    }
+  }, []);
+
+  const toggle = () => {
+    setDark((d) => {
+      const next = !d;
+      document.documentElement.classList.toggle('dark', next);
+      localStorage.setItem('theme', next ? 'dark' : 'light');
+      return next;
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle theme"
+      onClick={toggle}
+      className="rounded-md p-2 hover:bg-mwv-muted transition-all duration-150"
+    >
+      {dark ? '🌙' : '☀️'}
+    </button>
+  );
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,10 +1,11 @@
 "use client";
 import Image from 'next/image';
 import Link from 'next/link';
+import ThemeToggle from './ThemeToggle';
 
 export default function TopNav() {
   return (
-    <header className="sticky top-0 z-30 w-full bg-white/80 backdrop-blur border-b">
+    <header className="sticky top-0 z-30 w-full border-b border-mwv-border bg-mwv-card/80 backdrop-blur">
       <div className="container mx-auto flex items-center gap-3 px-4 py-3">
         <Link href="/" className="font-bold text-lg tracking-tight">MWV</Link>
         <nav className="hidden md:flex items-center gap-5 text-sm text-gray-600">
@@ -17,22 +18,24 @@ export default function TopNav() {
           <input
             type="search"
             placeholder="Search a thought..."
-            className="w-full rounded-md border bg-gray-50 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full rounded-lg border border-mwv-border bg-mwv-muted px-3 py-2 text-sm outline-none shadow-sm focus:ring-2 focus:ring-mwv-ring"
           />
         </div>
-        <button className="ml-3 rounded-md bg-blue-600 px-3 py-2 text-white text-sm hover:bg-blue-700">
+        <button className="ml-3 rounded-md bg-mwv-primary px-3 py-2 text-mwv-primary-foreground text-sm hover:bg-blue-700 transition-all duration-150">
           Create
         </button>
-        <button aria-label="Notifications" className="relative ml-2 rounded-full p-2 hover:bg-gray-100">
+        <button aria-label="Notifications" className="relative ml-2 rounded-full p-2 hover:bg-mwv-muted transition-all duration-150">
           <span className="text-xl">🔔</span>
           <span className="absolute -top-0.5 -right-0.5 inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-red-600 px-1 text-[10px] font-medium text-white">1</span>
         </button>
+        <ThemeToggle />
         <Image
           src="/avatar-placeholder.svg"
           alt="Profile"
           width={28}
           height={28}
-          className="ml-2 rounded-full ring-1 ring-gray-200"
+          className="ml-2 rounded-full ring-1 ring-mwv-border"
+          loading="lazy"
         />
       </div>
     </header>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -8,7 +9,31 @@ const config: Config = {
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        mwv: {
+          primary: '#2563eb',
+          'primary-foreground': '#ffffff',
+          muted: 'var(--mwv-muted)',
+          card: 'var(--mwv-card)',
+          border: 'var(--mwv-border)',
+          ring: 'var(--mwv-ring)',
+          background: 'var(--mwv-background)',
+          foreground: 'var(--mwv-foreground)',
+        },
+      },
+      fontSize: {
+        '2.5xl': ['1.75rem', { lineHeight: '2rem' }],
+      },
+      boxShadow: {
+        card: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+        'card-hover': '0 2px 8px 0 rgb(0 0 0 / 0.08)',
+      },
+      borderRadius: {
+        xl: '12px',
+        '2xl': '16px',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add Tailwind design tokens and card utilities
- introduce persistent light/dark ThemeToggle
- enhance PostCard and StanceBar with new UI patterns

## Testing
- `pnpm lint`
- `pnpm test` *(fails: No test files found)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689f6167cd68832d8f0ec65b1eb6b1f9