### PR TITLE
feat(ui): standardize card styles and stance visuals

### DIFF
--- a/docs/ui-tokens.md
+++ b/docs/ui-tokens.md
@@ -1,0 +1,35 @@
+# UI Tokens
+
+This project drives styling through Tailwind tokens extended in `tailwind.config.ts` and utility classes in `src/app/globals.css`.
+
+## Colors
+- `mwv.primary` / `mwv.primary-foreground`
+- `mwv.background`
+- `mwv.foreground`
+- `mwv.card`
+- `mwv.muted`
+- `mwv.border`
+- `mwv.ring`
+
+## Shadows
+- `shadow-card` – resting elevation
+- `shadow-card-hover` – hover elevation
+
+## Radius
+- `rounded-2xl` (16px)
+- `rounded-xl` (12px)
+
+## Spacing
+Uses an 8‑pt scale (multiples of 8 or 4). Additional helper:
+- `spacing[18]` = 4.5rem (72px)
+
+## Global utilities
+Defined in `globals.css`:
+- `.card` – primary card style
+- `.card--glass` – soft glass variant
+- `.card-hover` – hover elevation
+- `.pill` – rounded chip badge
+- `.skeleton` – loading placeholder
+- focus rings via `*:focus-visible`
+
+Keep layouts within a centered `container` and 12‑column grid, and space elements in 8‑pt increments.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,10 @@ body {
   @apply rounded-2xl border border-mwv-border bg-mwv-card shadow-card transition-all duration-150;
 }
 
+.card--glass {
+  @apply bg-white/30 dark:bg-slate-700/30 backdrop-blur-md;
+}
+
 .card-hover:hover {
   @apply shadow-card-hover ring-1 ring-mwv-ring ring-opacity-20 translate-y-[1px];
 }

--- a/src/components/ArgumentCard.tsx
+++ b/src/components/ArgumentCard.tsx
@@ -1,7 +1,21 @@
 import React from 'react';
 
-type ArgumentCardProps = { text: string };
+type ArgumentCardProps = {
+  text: string;
+  evidenceCount?: number;
+};
 
-export default function ArgumentCard({ text }: ArgumentCardProps) {
-  return <div className="border p-4 rounded text-sm">{text}</div>;
+export default function ArgumentCard({ text, evidenceCount }: ArgumentCardProps) {
+  return (
+    <article className="card card-hover p-4 text-sm">
+      <p>{text}</p>
+      {typeof evidenceCount === 'number' && (
+        <div className="mt-4">
+          <span className="pill" aria-label={`${evidenceCount} pieces of evidence`}>
+            Evidence · {evidenceCount}
+          </span>
+        </div>
+      )}
+    </article>
+  );
 }

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
 
-type IssueCardProps = { title: string; description?: string };
+type IssueCardProps = {
+  title: string;
+  description?: string;
+  evidenceCount?: number;
+};
 
-export default function IssueCard({ title, description }: IssueCardProps) {
+export default function IssueCard({ title, description, evidenceCount }: IssueCardProps) {
   return (
-    <div className="border p-4 rounded">
-      <div className="font-medium">{title}</div>
+    <article className="card card-hover p-4">
+      <h3 className="mb-2 text-sm font-medium">{title}</h3>
       {description && <p className="text-sm text-gray-600">{description}</p>}
-    </div>
+      {typeof evidenceCount === 'number' && (
+        <div className="mt-4">
+          <span className="pill" aria-label={`${evidenceCount} pieces of evidence`}>
+            Evidence · {evidenceCount}
+          </span>
+        </div>
+      )}
+    </article>
   );
 }

--- a/src/components/MotionCard.tsx
+++ b/src/components/MotionCard.tsx
@@ -8,9 +8,10 @@ export type MotionCardProps = {
   title: string;
   issueTitle?: string;
   census?: { total: number; counts: CensusCounts } | null;
+  evidenceCount?: number;
 };
 
-export default function MotionCard({ title, issueTitle, census }: MotionCardProps) {
+export default function MotionCard({ title, issueTitle, census, evidenceCount }: MotionCardProps) {
   const counts = census?.counts;
   const total = counts ? Math.max(1, counts.for + counts.against + counts.abstain) : 1;
   const forPct = counts ? Math.round((counts.for / total) * 100) : 0;
@@ -18,8 +19,8 @@ export default function MotionCard({ title, issueTitle, census }: MotionCardProp
   const abstainPct = counts ? Math.round((counts.abstain / total) * 100) : 0;
 
   return (
-    <div className="rounded-lg border bg-white p-4 shadow-sm">
-      <div className="flex items-center justify-between">
+    <article className="card card-hover p-4">
+      <header className="flex items-center justify-between">
         <div>
           <div className="text-sm font-semibold">{title}</div>
           {issueTitle && <div className="text-xs text-gray-500">{issueTitle}</div>}
@@ -27,17 +28,24 @@ export default function MotionCard({ title, issueTitle, census }: MotionCardProp
         <div className="text-right text-xs text-gray-600">
           <div>{census?.total ?? 0} responses</div>
         </div>
-      </div>
+      </header>
       {counts && (
-        <div className="mt-3 space-y-1">
-          <StanceBar forPct={forPct} againstPct={againstPct} abstainPct={abstainPct} />
+        <div className="mt-4 space-y-2">
+          <StanceBar counts={counts} />
           <div className="flex justify-between text-xs text-gray-600">
-            <span>{forPct}%</span>
-            <span>{againstPct}%</span>
-            <span>{abstainPct}%</span>
+            <span>For {forPct}%</span>
+            <span>Against {againstPct}%</span>
+            <span>Abstain {abstainPct}%</span>
           </div>
         </div>
       )}
-    </div>
+      {typeof evidenceCount === 'number' && (
+        <div className="mt-4">
+          <span className="pill" aria-label={`${evidenceCount} pieces of evidence`}>
+            Evidence · {evidenceCount}
+          </span>
+        </div>
+      )}
+    </article>
   );
 }

--- a/src/components/PositionCard.tsx
+++ b/src/components/PositionCard.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
 
-type PositionCardProps = { title: string; stance?: string };
+type PositionCardProps = {
+  title: string;
+  stance?: string;
+  evidenceCount?: number;
+};
 
-export default function PositionCard({ title, stance }: PositionCardProps) {
+export default function PositionCard({ title, stance, evidenceCount }: PositionCardProps) {
   return (
-    <div className="border p-4 rounded">
-      <div className="font-medium">{title}</div>
+    <article className="card card-hover p-4">
+      <h3 className="mb-2 text-sm font-medium">{title}</h3>
       {stance && <p className="text-sm text-gray-600">{stance}</p>}
-    </div>
+      {typeof evidenceCount === 'number' && (
+        <div className="mt-4">
+          <span className="pill" aria-label={`${evidenceCount} pieces of evidence`}>
+            Evidence · {evidenceCount}
+          </span>
+        </div>
+      )}
+    </article>
   );
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -16,7 +16,7 @@ export default function PostCard({ post }: { post: Post }) {
 
   return (
     <article className="card card-hover p-4">
-      <header className="mb-2 flex items-start gap-3">
+      <header className="mb-2 flex items-start gap-4">
         <Image
           src={post.author.avatarUrl || "/avatar-placeholder.svg"}
           alt={post.author.name}
@@ -32,27 +32,29 @@ export default function PostCard({ post }: { post: Post }) {
           </div>
           <p className="mt-1 text-[15px] text-gray-800">{post.text}</p>
         </div>
-        <button className="rounded p-1 text-gray-500 hover:bg-gray-50">⋯</button>
+        <button className="rounded p-2 text-gray-500 hover:bg-gray-50">⋯</button>
       </header>
 
-      <footer className="mt-3 flex flex-wrap items-center gap-3 text-sm text-gray-600">
+      <footer className="mt-4 flex flex-wrap items-center gap-4 text-sm text-gray-600">
         <button
-          className="flex items-center gap-1 rounded px-2 py-1 hover:bg-mwv-muted transition-all duration-150"
+          className="flex items-center gap-1 rounded px-2 py-2 hover:bg-mwv-muted transition-all duration-150"
           title="Draft a motion from this post"
         >
           <span aria-hidden>🚀</span>
           Promote
         </button>
-        <button className="rounded px-2 py-1 hover:bg-mwv-muted transition-all duration-150">Comment</button>
-        <button className="rounded px-2 py-1 hover:bg-mwv-muted transition-all duration-150">Share</button>
+        <button className="rounded px-2 py-2 hover:bg-mwv-muted transition-all duration-150">Comment</button>
+        <button className="rounded px-2 py-2 hover:bg-mwv-muted transition-all duration-150">Share</button>
         <button
-          className={`rounded px-2 py-1 hover:bg-mwv-muted transition-all duration-150 ${saved ? 'text-mwv-primary' : ''}`}
+          className={`rounded px-2 py-2 hover:bg-mwv-muted transition-all duration-150 ${saved ? 'text-mwv-primary' : ''}`}
           onClick={() => setSaved((s) => !s)}
         >
           {saved ? 'Saved' : 'Save'}
         </button>
         {typeof post.evidenceCount === 'number' && (
-          <span className="ml-auto pill">{post.evidenceCount} evidence</span>
+          <span className="ml-auto pill" aria-label={`${post.evidenceCount} pieces of evidence`}>
+            Evidence · {post.evidenceCount}
+          </span>
         )}
       </footer>
     </article>

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -1,5 +1,6 @@
 "use client";
 import StanceBar from './StanceBar';
+import SectionTitle from './SectionTitle';
 
 export default function RightRail() {
   const suggestedTopics = [
@@ -9,36 +10,46 @@ export default function RightRail() {
   ];
 
   const trending = [
-    { title: 'AI is essential for …', forPct: 62, againstPct: 28, abstainPct: 10 },
-    { title: 'Ban plastic bags in …', forPct: 54, againstPct: 36, abstainPct: 10 },
-    { title: 'Universal basic income …', forPct: 39, againstPct: 48, abstainPct: 13 },
+    { title: 'AI is essential for …', counts: { for: 62, against: 28, abstain: 10 } },
+    { title: 'Ban plastic bags in …', counts: { for: 54, against: 36, abstain: 10 } },
+    { title: 'Universal basic income …', counts: { for: 39, against: 48, abstain: 13 } },
   ];
 
   return (
-    <aside className="lg:col-span-4 xl:col-span-3 space-y-4">
-      <div className="rounded-lg border bg-white p-4">
-        <div className="text-sm font-medium">Suggested Topics</div>
-        <ul className="mt-3 space-y-2 text-sm">
+    <aside className="space-y-4 lg:col-span-4 xl:col-span-3">
+      <div className="card p-4">
+        <SectionTitle>Suggested Topics</SectionTitle>
+        <ul className="mt-4 flex flex-wrap gap-2 text-sm">
           {suggestedTopics.map((t) => (
             <li key={t.title}>
-              <button className="flex w-full items-center justify-between rounded-md px-2 py-1 hover:bg-gray-50">
-                <span>{t.title}</span>
-                <span className="text-gray-400">›</span>
+              <button className="rounded-full border border-mwv-border bg-mwv-muted px-3 py-1 hover:bg-mwv-border/30">
+                {t.title}
               </button>
             </li>
           ))}
         </ul>
       </div>
 
-      <div className="rounded-lg border bg-white p-4">
-        <div className="text-sm font-medium">Trending Motions</div>
-        <ul className="mt-3 space-y-3">
-          {trending.map((m) => (
-            <li key={m.title} className="space-y-1">
-              <div className="text-sm text-gray-800 line-clamp-1">{m.title}</div>
-              <StanceBar forPct={m.forPct} againstPct={m.againstPct} abstainPct={m.abstainPct} />
-            </li>
-          ))}
+      <div className="card p-4">
+        <SectionTitle>Trending Motions</SectionTitle>
+        <ul className="mt-4 space-y-4">
+          {trending.map((m) => {
+            const total = m.counts.for + m.counts.against + m.counts.abstain;
+            const forPct = Math.round((m.counts.for / total) * 100);
+            const againstPct = Math.round((m.counts.against / total) * 100);
+            const abstainPct = Math.round((m.counts.abstain / total) * 100);
+            return (
+              <li key={m.title} className="space-y-2">
+                <div className="text-sm text-gray-800 line-clamp-1">{m.title}</div>
+                <StanceBar counts={m.counts} size="sm" labels={false} />
+                <div className="flex justify-between text-xs text-gray-600">
+                  <span>For {forPct}%</span>
+                  <span>Against {againstPct}%</span>
+                  <span>Abstain {abstainPct}%</span>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       </div>
     </aside>

--- a/src/components/SectionTitle.tsx
+++ b/src/components/SectionTitle.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react';
+
+export default function SectionTitle({ children }: { children: ReactNode }) {
+  return <h2 className="text-lg font-semibold leading-snug">{children}</h2>;
+}

--- a/src/components/StanceBar.tsx
+++ b/src/components/StanceBar.tsx
@@ -6,45 +6,45 @@ export type Census5 = {
 };
 export type StanceBarProps =
   | {
-    // Legacy 3-way percentage mode
-    forPct: number;
-    againstPct: number;
-    abstainPct: number;
-    counts?: never;
-    census5?: never;
-    size?: 'sm' | 'md' | 'lg';
-    labels?: boolean;
-    compact?: boolean;
-  }
+      // Legacy 3-way percentage mode
+      forPct: number;
+      againstPct: number;
+      abstainPct: number;
+      counts?: never;
+      census5?: never;
+      size?: 'sm' | 'md' | 'lg';
+      labels?: boolean;
+    }
   | {
-    // Legacy 3-way counts mode
-    counts: StanceCounts3;
-    forPct?: never;
-    againstPct?: never;
-    abstainPct?: never;
-    census5?: never;
-    size?: 'sm' | 'md' | 'lg';
-    labels?: boolean;
-    compact?: boolean;
-  }
+      // Legacy 3-way counts mode
+      counts: StanceCounts3;
+      forPct?: never;
+      againstPct?: never;
+      abstainPct?: never;
+      census5?: never;
+      size?: 'sm' | 'md' | 'lg';
+      labels?: boolean;
+    }
   | {
-    // New 5-band census mode
-    census5: Census5;
-    forPct?: never;
-    againstPct?: never;
-    abstainPct?: never;
-    counts?: never;
-    size?: 'sm' | 'md' | 'lg';
-    labels?: boolean;
-    compact?: boolean;
-  };
+      // New 5-band census mode
+      census5: Census5;
+      forPct?: never;
+      againstPct?: never;
+      abstainPct?: never;
+      counts?: never;
+      size?: 'sm' | 'md' | 'lg';
+      labels?: boolean;
+    };
 
 export default function StanceBar(props: StanceBarProps) {
   const size = ('size' in props && props.size) || 'md';
   const labels = !('labels' in props) || props.labels !== false;
   const height = { sm: 'h-2', md: 'h-3', lg: 'h-4' }[size];
   const barClass = `flex ${height} w-full overflow-hidden rounded bg-mwv-muted`;
-  // New 5-band mode
+  const segmentStyle = (pattern: string) => ({
+    backgroundImage: pattern,
+  });
+
   if ('census5' in props && props.census5) {
     const c = props.census5;
     const total = Math.max(1, c.total || 0);
@@ -61,59 +61,115 @@ export default function StanceBar(props: StanceBarProps) {
     return (
       <div className="w-full">
         <div className={barClass} role="img" aria-label="Stance distribution (1 to 5)">
-          <div style={{ width: `${p1}%` }} className="bg-rose-600" aria-label={`1 Strongly Disagree ${p1}%`} />
-          <div style={{ width: `${p2}%` }} className="bg-orange-500" aria-label={`2 Disagree ${p2}%`} />
-          <div style={{ width: `${p3}%` }} className="bg-gray-500" aria-label={`3 Neutral ${p3}%`} />
-          <div style={{ width: `${p4}%` }} className="bg-emerald-400" aria-label={`4 Agree ${p4}%`} />
-          <div style={{ width: `${p5}%` }} className="bg-emerald-600" aria-label={`5 Strongly Agree ${p5}%`} />
+          <div
+            style={{ width: `${p1}%`, ...segmentStyle('repeating-linear-gradient(45deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+            className="bg-rose-600"
+            title={`1 Strongly Disagree ${p1}% (${c.counts[1] || 0})`}
+            aria-label={`1 Strongly Disagree ${p1}% (${c.counts[1] || 0})`}
+          />
+          <div
+            style={{ width: `${p2}%`, ...segmentStyle('repeating-linear-gradient(-45deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+            className="bg-orange-500"
+            title={`2 Disagree ${p2}% (${c.counts[2] || 0})`}
+            aria-label={`2 Disagree ${p2}% (${c.counts[2] || 0})`}
+          />
+          <div
+            style={{ width: `${p3}%`, ...segmentStyle('repeating-linear-gradient(0deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+            className="bg-gray-500"
+            title={`3 Neutral ${p3}% (${c.counts[3] || 0})`}
+            aria-label={`3 Neutral ${p3}% (${c.counts[3] || 0})`}
+          />
+          <div
+            style={{ width: `${p4}%`, ...segmentStyle('repeating-linear-gradient(45deg,rgba(255,255,255,0.3)0 2px,transparent 2px 4px)') }}
+            className="bg-emerald-400"
+            title={`4 Agree ${p4}% (${c.counts[4] || 0})`}
+            aria-label={`4 Agree ${p4}% (${c.counts[4] || 0})`}
+          />
+          <div
+            style={{ width: `${p5}%`, ...segmentStyle('repeating-linear-gradient(-45deg,rgba(255,255,255,0.3)0 2px,transparent 2px 4px)') }}
+            className="bg-emerald-600"
+            title={`5 Strongly Agree ${p5}% (${c.counts[5] || 0})`}
+            aria-label={`5 Strongly Agree ${p5}% (${c.counts[5] || 0})`}
+          />
         </div>
         {labels && (
           <div className="mt-2 grid grid-cols-5 text-[11px] text-gray-600">
-            <div className="text-left">1: {c.counts[1] || 0}</div>
-            <div className="text-left">2: {c.counts[2] || 0}</div>
-            <div className="text-center">3: {c.counts[3] || 0}</div>
-            <div className="text-right">4: {c.counts[4] || 0}</div>
-            <div className="text-right">5: {c.counts[5] || 0}</div>
+            <div className="text-left">1: {c.counts[1] || 0} ({p1}%)</div>
+            <div className="text-left">2: {c.counts[2] || 0} ({p2}%)</div>
+            <div className="text-center">3: {c.counts[3] || 0} ({p3}%)</div>
+            <div className="text-right">4: {c.counts[4] || 0} ({p4}%)</div>
+            <div className="text-right">5: {c.counts[5] || 0} ({p5}%)</div>
           </div>
         )}
       </div>
     );
   }
-  // Legacy 3-way counts mode
+
   if ('counts' in props && props.counts) {
     const counts = props.counts;
     const forCount = counts.for || 0;
     const againstCount = counts.against || 0;
     const abstainCount = counts.abstain || 0;
     const total = Math.max(1, forCount + againstCount + abstainCount);
-    const _pct = (n: number) => Math.round((n / total) * 100);
+    const pct = (n: number) => Math.round((n / total) * 100);
     return (
       <div className="w-full">
-        <div className={barClass}>
-          <div style={{ width: `${_pct(forCount)}%` }} className="bg-emerald-500" />
-          <div style={{ width: `${_pct(againstCount)}%` }} className="bg-rose-500" />
-          <div style={{ width: `${_pct(abstainCount)}%` }} className="bg-yellow-400" />
+        <div className={barClass} role="img" aria-label="Stance distribution">
+          <div
+            style={{ width: `${pct(forCount)}%`, ...segmentStyle('repeating-linear-gradient(45deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+            className="bg-emerald-500"
+            title={`For ${pct(forCount)}% (${forCount})`}
+            aria-label={`For ${pct(forCount)}% (${forCount})`}
+          />
+          <div
+            style={{ width: `${pct(againstCount)}%`, ...segmentStyle('repeating-linear-gradient(-45deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+            className="bg-rose-500"
+            title={`Against ${pct(againstCount)}% (${againstCount})`}
+            aria-label={`Against ${pct(againstCount)}% (${againstCount})`}
+          />
+          <div
+            style={{ width: `${pct(abstainCount)}%`, ...segmentStyle('repeating-linear-gradient(0deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+            className="bg-gray-500"
+            title={`Abstain ${pct(abstainCount)}% (${abstainCount})`}
+            aria-label={`Abstain ${pct(abstainCount)}% (${abstainCount})`}
+          />
         </div>
         {labels && (
           <div className="mt-2 flex items-center justify-between text-xs text-gray-600">
-            <div>For: {forCount}</div>
-            <div>Against: {againstCount}</div>
-            <div>Abstain: {abstainCount}</div>
+            <div>For: {forCount} ({pct(forCount)}%)</div>
+            <div>Against: {againstCount} ({pct(againstCount)}%)</div>
+            <div>Abstain: {abstainCount} ({pct(abstainCount)}%)</div>
           </div>
         )}
       </div>
     );
   }
-  // Percentage mode
+
   if ('forPct' in props) {
     const { forPct, againstPct, abstainPct } = props;
     return (
       <div className={barClass} role="img" aria-label="Stance distribution">
-        <div className="h-full bg-emerald-500" style={{ width: `${forPct || 0}%` }} aria-label={`For ${forPct || 0}%`} />
-        <div className="h-full bg-rose-500" style={{ width: `${againstPct || 0}%` }} aria-label={`Against ${againstPct || 0}%`} />
-        <div className="h-full bg-gray-500" style={{ width: `${abstainPct || 0}%` }} aria-label={`Abstain ${abstainPct || 0}%`} />
+        <div
+          className="h-full bg-emerald-500"
+          style={{ width: `${forPct || 0}%`, ...segmentStyle('repeating-linear-gradient(45deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+          title={`For ${forPct || 0}%`}
+          aria-label={`For ${forPct || 0}%`}
+        />
+        <div
+          className="h-full bg-rose-500"
+          style={{ width: `${againstPct || 0}%`, ...segmentStyle('repeating-linear-gradient(-45deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+          title={`Against ${againstPct || 0}%`}
+          aria-label={`Against ${againstPct || 0}%`}
+        />
+        <div
+          className="h-full bg-gray-500"
+          style={{ width: `${abstainPct || 0}%`, ...segmentStyle('repeating-linear-gradient(0deg,rgba(255,255,255,0.3)0 4px,transparent 4px 8px)') }}
+          title={`Abstain ${abstainPct || 0}%`}
+          aria-label={`Abstain ${abstainPct || 0}%`}
+        />
       </div>
     );
   }
+
   return null;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,6 +22,9 @@ const config: Config = {
           foreground: 'var(--mwv-foreground)',
         },
       },
+      spacing: {
+        18: '4.5rem', // 72px helper for 8pt scale
+      },
       fontSize: {
         '2.5xl': ['1.75rem', { lineHeight: '2rem' }],
       },


### PR DESCRIPTION
## Summary
- extend Tailwind tokens and document spacing/shadow usage
- add card utilities and glass variant; update cards to use unified spacing and evidence chips
- refine stance bar with counts, percent labels, and accessibility patterns
- polish right rail with section titles, chip topics, and mini stance summaries

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b779cab0832d932966454ba8961d